### PR TITLE
Add missing #include to the header file.

### DIFF
--- a/src/qt/buynamespage.h
+++ b/src/qt/buynamespage.h
@@ -4,6 +4,7 @@
 #include <qt/platformstyle.h>
 
 #include <QWidget>
+#include <optional>
 
 class WalletModel;
 


### PR DESCRIPTION
Building Namecoin Core with Qt fails without this.